### PR TITLE
Use numpy.lib.stride_tricks to provide another toeplitz function.

### DIFF
--- a/src/py_toeplitz/__init__.py
+++ b/src/py_toeplitz/__init__.py
@@ -6,12 +6,53 @@ from functools import partial
 
 from numpy import dot, empty, zeros, newaxis, around
 from numpy.fft import fft, ifft, rfft, irfft
+from numpy.lib.stride_tricks import as_strided
 
 from scipy.sparse.linalg.interface import LinearOperator
 from scipy.signal import convolve
 from scipy.linalg import solve_toeplitz
 
 from .__version__ import VERSION as __version__  # noqa: F401
+
+
+def stride_tricks_toeplitz(first_column, first_row=None):
+    """Use stride tricks to create a toeplitz matrix.
+
+    Parameters
+    ----------
+    first_column: array_like[M]
+    first_row: array_like[N], optional
+
+    Returns
+    -------
+    toeplitz_array: array_like[M, N]
+
+    Examples
+    --------
+    >>> stride_tricks_toeplitz([4, 3, 2, 1, 0])
+    array([[4, 3, 2, 1, 0],
+           [3, 4, 3, 2, 1],
+           [2, 3, 4, 3, 2],
+           [1, 2, 3, 4, 3],
+           [0, 1, 2, 3, 4]])
+    >>> stride_tricks_toeplitz([4, 3, 2, 1, 0], [0, 1, 2, 3, 4])
+    array([[4, 1, 2, 3, 4],
+           [3, 4, 1, 2, 3],
+           [2, 3, 4, 1, 2],
+           [1, 2, 3, 4, 1],
+           [0, 1, 2, 3, 4]])
+    """
+    first_column = asarray(first_column)
+    if first_row is None:
+        first_row = first_column
+    n_rows = len(first_column)
+    n_cols = len(first_row)
+    dtype = first_column.dtype
+    data = empty((n_rows + n_cols - 1), dtype=dtype)
+    data[-n_cols:] = first_row
+    data[:n_rows] = first_column[::-1]
+    return as_strided(data[-n_cols:], (n_rows, n_cols),
+                      (-dtype.itemsize, dtype.itemsize))
 
 
 class Toeplitz(LinearOperator):

--- a/src/py_toeplitz/__init__.py
+++ b/src/py_toeplitz/__init__.py
@@ -4,7 +4,7 @@ Various implementations of operations involving toeplitz matrices.
 """
 from functools import partial
 
-from numpy import dot, empty, zeros, newaxis, around
+from numpy import dot, empty, zeros, newaxis, around, asarray
 from numpy.fft import fft, ifft, rfft, irfft
 from numpy.lib.stride_tricks import as_strided
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -15,7 +15,8 @@ from hypothesis.extra.numpy import (arrays, floating_dtypes, integer_dtypes,
 from hypothesis.strategies import (shared, integers, tuples, floats,
                                    builds)
 
-from py_toeplitz import Toeplitz, ConvolveToeplitz, FFTToeplitz
+from py_toeplitz import (Toeplitz, ConvolveToeplitz, FFTToeplitz,
+                         stride_tricks_toeplitz)
 from py_toeplitz.cytoeplitz import CyToeplitz
 
 MAX_ARRAY = 10
@@ -25,7 +26,8 @@ INTEGER_SIZES = (8, 16, 32, 64)
 COMPLEX_SIZES = (64, 128)
 INT8_MAX = 128
 OPERATOR_LIST = (Toeplitz, CyToeplitz,
-                 ConvolveToeplitz, FFTToeplitz)
+                 ConvolveToeplitz, FFTToeplitz,
+                 stride_tricks_toeplitz)
 ATOL_MIN = 1e-14
 
 


### PR DESCRIPTION
Uses the same low-memory trick as Toeplitz and CyToeplitz, but
provides an ndarray to back it.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Represent the Toeplitz matrix using a `numpy.ndarray` rather than a `LinearOperator`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I thought it might be interesting to see how this performed in the benchmarks.  The answer is slowly.  I think numpy copies the contents into a contiguous array before calling BLAS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added to the list of "operators" to test in the parametrized tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I give permission for my code to be distributed under the existing license
<!-- this may need to be okayed by your company's legal department if you did this on work time. -->
