### PR TITLE
Make sure _static dir is present for tox runs.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,12 +41,14 @@ commands=
 
 [testenv:docs]
 changedir=doc
+whitelist_externals=mkdir
 deps=
     sphinx
     Cython>=0.16
     numpy
     scipy>=0.16.0
 commands=
+    mkdir source/_static
     sphinx-build -q -W --keep-going -b html -d {envtmpdir}/doctrees source {envtmpdir}/html
     sphinx-build -q -W -b texinfo -d {envtmpdir}/doctrees source {envtmpdir}/texinfo
     sphinx-build -q -W -b man -d {envtmpdir}/doctrees source {envtmpdir}/man


### PR DESCRIPTION
This should get CI working again.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an mkdir for the _static directory sphinx expects to be present.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Weekly tox runs were failing because the directory wasn't there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tox locally after deleting _static dir, which failed before this change and passed after.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I give permission for my code to be distributed under the existing license
<!-- this may need to be okayed by your company's legal department if you did this on work time. -->
